### PR TITLE
fix: replace fragile line-number sed with pattern-based for Arch Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,12 +25,12 @@ do
                 ;;
             dnf)
                 sudo dnf install -y freeglut-devel libjpeg-turbo-devel openmpi-devel libXmu-devel libXi-devel cmake boost-devel
-                sed -i '62s/.*/set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -lglut")/' CMakeLists.txt
+                sed -i 's/^set(CMAKE_CXX_FLAGS.*-std=c++17.*)/set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -lglut")/' CMakeLists.txt
                 done=1
                 ;;
             pacman)
                 sudo pacman -Sy freeglut libjpeg openmpi openmpi libxmu libxi boost cmake
-                sed -i '62s/.*/set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -lglut")/' CMakeLists.txt
+                sed -i 's/^set(CMAKE_CXX_FLAGS.*-std=c++17.*)/set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -lglut")/' CMakeLists.txt
                 done=1
                 ;;
             *)


### PR DESCRIPTION
On Arch Linux, install.sh uses a hardcoded line number to patch CMakeLists.txt:
```bash
sed -i '62s/.*/.../' CMakeLists.txt
```
This overwrites whatever happens to be on line 62, which causes CMake to fail with:
```bash
CMake Error: No SOURCES given to target: GLUILib
```
because the SOURCES_GLUI glob definition gets destroyed.

**Fix**
Replace the hardcoded line number with a pattern-based match that targets the actual line by its content:
```bash
sed -i 's/^set(CMAKE_CXX_FLAGS.*-std=c++17.*)/set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -lglut")/' CMakeLists.txt
```
This way the replacement is robust regardless of line numbering changes in the file.